### PR TITLE
implicit-fallthrough errors fixes when using additional warning flags

### DIFF
--- a/murmurhash.c
+++ b/murmurhash.c
@@ -50,8 +50,13 @@ murmurhash (const char *key, uint32_t len, uint32_t seed) {
 
   // remainder
   switch (len & 3) { // `len % 4'
-    case 3: k ^= (tail[2] << 16);
-    case 2: k ^= (tail[1] << 8);
+    case 3: 
+      k ^= (tail[2] << 16);
+      break;
+    
+    case 2:
+      k ^= (tail[1] << 8);
+      break;
 
     case 1:
       k ^= tail[0];
@@ -59,6 +64,7 @@ murmurhash (const char *key, uint32_t len, uint32_t seed) {
       k = (k << r1) | (k >> (32 - r1));
       k *= c2;
       h ^= k;
+      break;
   }
 
   h ^= len;


### PR DESCRIPTION
Adding break statements in case switches in source code helps the portability and produces less warnings.